### PR TITLE
Enhance logging to include timestamp and client IP address

### DIFF
--- a/Controllers/ManagementController.cs
+++ b/Controllers/ManagementController.cs
@@ -380,7 +380,7 @@ public class ManagementController : ControllerBase
         if (_proxyService.TrustedProxies.Length > 0 &&
             !_ipService.TrustedProxy)
         {
-            logMsg += "* ";
+            logMsg += "*";
         }
 
         logMsg += $" {text}";

--- a/Controllers/ManagementController.cs
+++ b/Controllers/ManagementController.cs
@@ -5,17 +5,21 @@ namespace Kosync.Controllers;
 [ApiController]
 public class ManagementController : ControllerBase
 {
-    private KosyncDb _db;
-
-    private UserService _userService;
-
     private ILogger<ManagementController> _logger;
 
-    public ManagementController(KosyncDb db, UserService userService, ILogger<ManagementController> logger)
+    private ProxyService _proxyService;
+    private IPService _ipService;
+    private KosyncDb _db;
+    private UserService _userService;
+
+
+    public ManagementController(ILogger<ManagementController> logger, ProxyService proxyService, IPService ipService, KosyncDb db, UserService userService)
     {
+        _logger = logger;
+        _proxyService = proxyService;
+        _ipService = ipService;
         _db = db;
         _userService = userService;
-        _logger = logger;
     }
 
     [HttpGet("/manage/users")]
@@ -23,7 +27,14 @@ public class ManagementController : ControllerBase
     {
         if (!_userService.IsAuthenticated)
         {
-            _logger?.Log(LogLevel.Warning, "Unauthenticated GET request to /manage/users.");
+            if (string.IsNullOrEmpty(_userService.Username))
+            {
+                LogWarning("Unauthenticated GET request to /manage/users.");
+            }
+            else
+            {
+                LogWarning($"Unauthenticated GET request to /manage/users with username [{_userService.Username}].");
+            }
 
             return StatusCode(401, new
             {
@@ -33,7 +44,7 @@ public class ManagementController : ControllerBase
 
         if (!_userService.IsAdmin)
         {
-            _logger?.Log(LogLevel.Warning, $"Unauthorized GET request to /manage/users from user [{_userService.Username}].");
+            LogWarning($"Unauthorized GET request to /manage/users from user [{_userService.Username}].");
 
             return StatusCode(401, new
             {
@@ -43,7 +54,7 @@ public class ManagementController : ControllerBase
 
         if (!_userService.IsActive)
         {
-            _logger?.Log(LogLevel.Warning, $"GET request to /manage/users received from inactive user [{_userService.Username}].");
+            LogWarning($"GET request to /manage/users received from inactive user [{_userService.Username}].");
 
             return StatusCode(401, new
             {
@@ -51,7 +62,6 @@ public class ManagementController : ControllerBase
             });
         }
 
-        _logger?.Log(LogLevel.Information, $"User [{_userService.Username}] requested /manage/users");
 
         var userCollection = _db.Context.GetCollection<User>("users");
 
@@ -64,6 +74,7 @@ public class ManagementController : ControllerBase
             documentCount = i.Documents.Count()
         });
 
+        LogInfo($"User [{_userService.Username}] requested /manage/users");
         return StatusCode(200, users);
     }
 
@@ -72,7 +83,14 @@ public class ManagementController : ControllerBase
     {
         if (!_userService.IsAuthenticated)
         {
-            _logger?.Log(LogLevel.Warning, "Unauthenticated POST request to /manage/users.");
+            if (string.IsNullOrEmpty(_userService.Username))
+            {
+                LogWarning("Unauthenticated POST request to /manage/users.");
+            }
+            else
+            {
+                LogWarning($"Unauthenticated POST request to /manage/users with username [{_userService.Username}].");
+            }
 
             return StatusCode(401, new
             {
@@ -82,7 +100,7 @@ public class ManagementController : ControllerBase
 
         if (!_userService.IsAdmin)
         {
-            _logger?.Log(LogLevel.Warning, $"Unauthorized POST request to /manage/users from user [{_userService.Username}].");
+            LogWarning($"Unauthorized POST request to /manage/users from user [{_userService.Username}].");
 
             return StatusCode(401, new
             {
@@ -92,7 +110,7 @@ public class ManagementController : ControllerBase
 
         if (!_userService.IsActive)
         {
-            _logger?.Log(LogLevel.Warning, $"POST request to /manage/users received from inactive user [{_userService.Username}].");
+            LogWarning($"POST request to /manage/users received from inactive user [{_userService.Username}].");
 
             return StatusCode(401, new
             {
@@ -123,8 +141,7 @@ public class ManagementController : ControllerBase
         userCollection.Insert(user);
         userCollection.EnsureIndex(u => u.Username);
 
-        _logger?.Log(LogLevel.Information, $"User [{payload.username}] created by user [{_userService.Username}]");
-
+        LogInfo($"User [{payload.username}] created by user [{_userService.Username}]");
         return StatusCode(200, new
         {
             message = "User created successfully"
@@ -136,7 +153,14 @@ public class ManagementController : ControllerBase
     {
         if (!_userService.IsAuthenticated)
         {
-            _logger?.Log(LogLevel.Warning, "Unauthenticated GET request to /manage/users/documents.");
+            if (string.IsNullOrEmpty(_userService.Username))
+            {
+                LogWarning("Unauthenticated GET request to /manage/users/documents.");
+            }
+            else
+            {
+                LogWarning($"Unauthenticated GET request to /manage/users/documents with username [{_userService.Username}].");
+            }
 
             return StatusCode(401, new
             {
@@ -149,7 +173,7 @@ public class ManagementController : ControllerBase
             !username.Equals(_userService.Username, StringComparison.OrdinalIgnoreCase))
             // allow a user to request their own docs
         {
-            _logger?.Log(LogLevel.Warning, $"Unauthorized GET request to /manage/users/documents from user [{_userService.Username}].");
+            LogWarning($"Unauthorized GET request to /manage/users/documents from user [{_userService.Username}].");
 
             return StatusCode(401, new
             {
@@ -159,7 +183,7 @@ public class ManagementController : ControllerBase
 
         if (!_userService.IsActive)
         {
-            _logger?.Log(LogLevel.Warning, $"GET request to /manage/users/documents received from inactive user [{_userService.Username}].");
+            LogWarning($"GET request to /manage/users/documents received from inactive user [{_userService.Username}].");
 
             return StatusCode(401, new
             {
@@ -167,7 +191,7 @@ public class ManagementController : ControllerBase
             });
         }
 
-        _logger?.Log(LogLevel.Information, $"User [{username}]'s documents requested by [{_userService.Username}]");
+        LogInfo($"User [{username}]'s documents requested by [{_userService.Username}]");
 
         var userCollection = _db.Context.GetCollection<User>("users");
 
@@ -188,7 +212,14 @@ public class ManagementController : ControllerBase
     {
         if (!_userService.IsAuthenticated)
         {
-            _logger?.Log(LogLevel.Warning, "Unauthenticated PUT request to /manage/users/active.");
+            if (string.IsNullOrEmpty(_userService.Username))
+            {
+                LogWarning("Unauthenticated PUT request to /manage/users/active.");
+            }
+            else
+            {
+                LogWarning($"Unauthenticated PUT request to /manage/users/active with username [{_userService.Username}].");
+            }
 
             return StatusCode(401, new
             {
@@ -198,7 +229,7 @@ public class ManagementController : ControllerBase
 
         if (!_userService.IsAdmin)
         {
-            _logger?.Log(LogLevel.Warning, $"Unauthorized PUT request to /manage/users/active from user [{_userService.Username}].");
+            LogWarning($"Unauthorized PUT request to /manage/users/active from user [{_userService.Username}].");
 
             return StatusCode(401, new
             {
@@ -208,7 +239,7 @@ public class ManagementController : ControllerBase
 
         if (!_userService.IsActive)
         {
-            _logger?.Log(LogLevel.Warning, $"PUT request to /manage/users/active received from inactive user [{_userService.Username}].");
+            LogWarning($"PUT request to /manage/users/active received from inactive user [{_userService.Username}].");
 
             return StatusCode(401, new
             {
@@ -218,6 +249,8 @@ public class ManagementController : ControllerBase
 
         if (username == "admin")
         {
+            LogWarning($"Attempt to toggle admin user active from user [{_userService.Username}].");
+
             return StatusCode(400, new
             {
                 message = "Cannot update admin user"
@@ -229,6 +262,8 @@ public class ManagementController : ControllerBase
         var user = userCollection.FindOne(i => i.Username == username);
         if (user is null)
         {
+            LogInfo($"PUT request to /manage/users/active received from [{_userService.Username}] but target username [{username}] does not exist.");
+
             return StatusCode(400, new
             {
                 message = "User does not exist"
@@ -238,7 +273,7 @@ public class ManagementController : ControllerBase
         user.IsActive = !user.IsActive;
         userCollection.Update(user);
 
-        _logger?.Log(LogLevel.Information, $"User [{username}] set to {(user.IsActive ? "active" : "inactive")} by user [{_userService.Username}]");
+        LogInfo($"User [{username}] set to {(user.IsActive ? "active" : "inactive")} by user [{_userService.Username}]");
 
         return StatusCode(200, new
         {
@@ -251,7 +286,14 @@ public class ManagementController : ControllerBase
     {
         if (!_userService.IsAuthenticated)
         {
-            _logger?.Log(LogLevel.Warning, "Unauthenticated PUT request to /manage/users/password.");
+            if (string.IsNullOrEmpty(_userService.Username))
+            {
+                LogWarning("Unauthenticated PUT request to /manage/users/password.");
+            }
+            else
+            {
+                LogWarning($"Unauthenticated PUT request to /manage/users/password with username [{_userService.Username}].");
+            }
 
             return StatusCode(401, new
             {
@@ -261,7 +303,7 @@ public class ManagementController : ControllerBase
 
         if (!_userService.IsAdmin)
         {
-            _logger?.Log(LogLevel.Warning, $"Unauthorized PUT request to /manage/users/password from user [{_userService.Username}].");
+            LogWarning($"Unauthorized PUT request to /manage/users/password from user [{_userService.Username}].");
 
             return StatusCode(401, new
             {
@@ -271,7 +313,7 @@ public class ManagementController : ControllerBase
 
         if (!_userService.IsActive)
         {
-            _logger?.Log(LogLevel.Warning, $"PUT request to /manage/users/password received from inactive user [{_userService.Username}].");
+            LogWarning($"PUT request to /manage/users/password received from inactive user [{_userService.Username}].");
 
             return StatusCode(401, new
             {
@@ -290,6 +332,7 @@ public class ManagementController : ControllerBase
 
         if (username == "admin")
         {
+            LogWarning($"Attempt to change admin password from user [{_userService.Username}].");
             return StatusCode(400, new
             {
                 message = "Cannot update admin user"
@@ -301,6 +344,7 @@ public class ManagementController : ControllerBase
         var user = userCollection.FindOne(i => i.Username == username);
         if (user is null)
         {
+            LogWarning($"Password change request received from [{_userService.Username}] but target username [{username}] does not exist.");
             return StatusCode(400, new
             {
                 message = "User does not exist"
@@ -310,11 +354,37 @@ public class ManagementController : ControllerBase
         user.PasswordHash = Utility.HashPassword(payload.password);
         userCollection.Update(user);
 
-        _logger?.Log(LogLevel.Information, $"User [{username}]'s password updated by [{_userService.Username}].");
-
+        LogInfo($"User [{username}]'s password updated by [{_userService.Username}].");
         return StatusCode(200, new
         {
             message = "Password changed successfully"
         });
+    }
+
+    private void LogInfo(string text)
+    {
+        Log(LogLevel.Information, text);
+    }
+
+    private void LogWarning(string text)
+    {
+        Log(LogLevel.Warning, text);
+    }
+
+    private void Log(LogLevel level, string text)
+    {
+        string logMsg = $"[{DateTime.Now.ToString("yyyy/MM/dd HH:mm:ss")}] [{_ipService.ClientIP}]";
+
+
+        // If trusted proxies are set but this request comes from another address, mark it
+        if (_proxyService.TrustedProxies.Length > 0 &&
+            !_ipService.TrustedProxy)
+        {
+            logMsg += "* ";
+        }
+
+        logMsg += $" {text}";
+
+        _logger?.Log(level, logMsg);
     }
 }

--- a/Controllers/SyncController.cs
+++ b/Controllers/SyncController.cs
@@ -171,7 +171,7 @@ public class SyncController : ControllerBase
 
         userCollection.Update(user);
 
-        LogInfo($"Received progress update for user [{_userService.Username}] with document hash [{payload.document}].");
+        LogInfo($"Received progress update for user [{_userService.Username}] from device [{payload.device}] with document hash [{payload.document}].");
         return StatusCode(200, new
         {
             document = document.DocumentHash,

--- a/Controllers/SyncController.cs
+++ b/Controllers/SyncController.cs
@@ -254,7 +254,7 @@ public class SyncController : ControllerBase
         if (_proxyService.TrustedProxies.Length > 0 &&
             !_ipService.TrustedProxy)
         {
-            logMsg += "* ";
+            logMsg += "*";
         }
 
         logMsg += $" {text}";

--- a/Program.cs
+++ b/Program.cs
@@ -1,13 +1,25 @@
+using System.Net;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddHttpContextAccessor();
+
+
+builder.Services.AddSingleton<ProxyService, ProxyService>();
+builder.Services.AddScoped<IPService, IPService>();
+builder.Services.AddScoped<UserService, UserService>();
+builder.Services.AddScoped<KosyncDb, KosyncDb>();
+
+
 builder.Services.AddControllers();
 
-builder.Services.AddScoped<KosyncDb, KosyncDb>();
-builder.Services.AddScoped<UserService, UserService>();
 
 var app = builder.Build();
 
+app.UseForwardedHeaders();
+
 app.MapControllers();
+
+
 
 app.Run();

--- a/Program.cs
+++ b/Program.cs
@@ -14,6 +14,17 @@ builder.Services.AddScoped<KosyncDb, KosyncDb>();
 builder.Services.AddControllers();
 
 
+if (Environment.GetEnvironmentVariable("SINGLE_LINE_LOGGING") == "true")
+{
+
+    builder.Logging.ClearProviders();
+    builder.Logging.AddSimpleConsole(options =>
+    {
+        options.SingleLine = true;
+    });
+}
+
+
 var app = builder.Build();
 
 app.UseForwardedHeaders();

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ services:
       - ASPNETCORE_HTTP_PORTS=8080
       - ADMIN_PASSWORD=<super-strong-password>
       - REGISTRATION_DISABLED=false
+      - TRUSTED_PROXIES=1.2.3.4, ::1
     user: 1000:1000
 ```
 
@@ -31,6 +32,8 @@ services:
 An admin user with the username `admin` will be created when the server first starts. If you provide the `ADMIN_PASSWORD` environment variable, the password for this admin user will be changed to the value provided. If you do not provide a value, the password for this user will be set to `admin`. The recommendation is to set this to a strong password generated with a password manager like [Bitwarden](https://bitwarden.com/). This admin user can be used to interact with the management API.
 
 If the `REGISTRATION_DISABLED` environment variable is set to `true`, the sync server will respond with an `User registration is disabled` error message when trying to create a new user. This is useful if you expose your sync server to the public internet, but don't want anyone to be able to register a user. This is a feature that is not available in the official sync server.
+
+The `TRUSTED_PROXIES` environment variable is an optional variable that defines one or more trusted proxies. It should be a comma delineated list of IPv4 or IPv6 addresses. If `TRUSTED_PROXIES` is set, when a request comes through a trusted proxy, the X-Forwarded-For header will be checked for the client's real IP address to use in logging. If `TRUSTED_PROXIES` is not set, or if a request does not come through a trusted proxy, the request's source IP address will be used for logging. Requests that do not come through a trusted proxy when `TRUSTED_PROXIES` is set will be marked with an asterisk (*) in the logs.
 
 Mapping user to `1000:1000` is just a way to ensure the database files are created using your own user, rather than root. If your operating system user ID is different from `1000:1000`, change it to yours.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ If the `REGISTRATION_DISABLED` environment variable is set to `true`, the sync s
 
 The `TRUSTED_PROXIES` environment variable is an optional variable that defines one or more trusted proxies. It should be a comma delineated list of IPv4 or IPv6 addresses. If `TRUSTED_PROXIES` is set, when a request comes through a trusted proxy, the X-Forwarded-For header will be checked for the client's real IP address to use in logging. If `TRUSTED_PROXIES` is not set, or if a request does not come through a trusted proxy, the request's source IP address will be used for logging. Requests that do not come through a trusted proxy when `TRUSTED_PROXIES` is set will be marked with an asterisk (*) in the logs.
 
+If you would like logging output to be on a single line, you may add the environment variable `SINGLE_LINE_LOGGING` and set it to `true`.
+
 Mapping user to `1000:1000` is just a way to ensure the database files are created using your own user, rather than root. If your operating system user ID is different from `1000:1000`, change it to yours.
 
 This example doesn't expose any ports for the container, however the sync server is accessible via port `8080` inside the container. The recommendation is to expose the server via a reverse proxy such as [Nginx Proxy Manager](https://nginxproxymanager.com/).

--- a/Services/IPService.cs
+++ b/Services/IPService.cs
@@ -62,6 +62,8 @@ public class IPService
         {
             _trustedProxy = true;
 
+            LogInfo(_context?.Request.Headers["X-Forwarded-For"]);
+
             string? forwardedFor = _context?.Request.Headers["X-Forwarded-For"].FirstOrDefault();
             if (!string.IsNullOrEmpty(forwardedFor))
             {

--- a/Services/IPService.cs
+++ b/Services/IPService.cs
@@ -55,11 +55,28 @@ public class IPService
 
         _ipLoaded = true;
 
-        string? connectingIP = _context?.Connection.RemoteIpAddress?.ToString();
+        string? connectingIP;
+
+        IPAddress? remoteIP = _context?.Connection.RemoteIpAddress;
+
+        if (remoteIP is null)
+        {
+            connectingIP = "";
+        }
+        else
+        {
+            if (remoteIP.IsIPv4MappedToIPv6)
+            {
+                remoteIP = remoteIP.MapToIPv4();
+            }
+
+            connectingIP = remoteIP.ToString();
+        }
+
         if (connectingIP is null) { connectingIP = ""; }
 
-        LogInfo("Forwarded - " + _context?.Request.Headers["X-Forwarded-For"]);
-        LogInfo("Actual - " + _context?.Connection.RemoteIpAddress.ToString());
+        //LogInfo("Forwarded - " + _context?.Request.Headers["X-Forwarded-For"]);
+        //LogInfo("Actual - " + _context?.Connection.RemoteIpAddress.ToString());
         if (_proxyService.TrustedProxies.Contains(connectingIP))
         {
             _trustedProxy = true;

--- a/Services/IPService.cs
+++ b/Services/IPService.cs
@@ -58,11 +58,11 @@ public class IPService
         string? connectingIP = _context?.Connection.RemoteIpAddress?.ToString();
         if (connectingIP is null) { connectingIP = ""; }
 
+        LogInfo(_context?.Request.Headers["X-Forwarded-For"]);
         if (_proxyService.TrustedProxies.Contains(connectingIP))
         {
             _trustedProxy = true;
 
-            LogInfo(_context?.Request.Headers["X-Forwarded-For"]);
 
             string? forwardedFor = _context?.Request.Headers["X-Forwarded-For"].FirstOrDefault();
             if (!string.IsNullOrEmpty(forwardedFor))

--- a/Services/IPService.cs
+++ b/Services/IPService.cs
@@ -58,7 +58,8 @@ public class IPService
         string? connectingIP = _context?.Connection.RemoteIpAddress?.ToString();
         if (connectingIP is null) { connectingIP = ""; }
 
-        LogInfo(_context?.Request.Headers["X-Forwarded-For"]);
+        LogInfo("Forwarded - " + _context?.Request.Headers["X-Forwarded-For"]);
+        LogInfo("Actual - " + _context?.Connection.RemoteIpAddress.ToString());
         if (_proxyService.TrustedProxies.Contains(connectingIP))
         {
             _trustedProxy = true;

--- a/Services/IPService.cs
+++ b/Services/IPService.cs
@@ -1,0 +1,109 @@
+﻿
+
+using System.Net;
+
+namespace Kosync.Services;
+
+public class IPService
+{
+    private readonly HttpContext? _context;
+    private readonly ILogger<IPService>? _logger;
+    private readonly ProxyService _proxyService;
+
+    private bool _ipLoaded = false;
+
+
+    private bool _trustedProxy = false;
+    /// <summary>
+    /// Is this connection from a trusted proxy
+    /// </summary>
+    public bool TrustedProxy
+    {
+        get
+        {
+            LoadIP();
+            return _trustedProxy;
+        }
+    }
+
+    private string _clientIP = "";
+    /// <summary>
+    /// The IP address of the client
+    /// </summary>
+    public string ClientIP
+    {
+        get
+        {
+            LoadIP();
+            return _clientIP;
+        }
+    }
+
+
+    public IPService(IHttpContextAccessor accessor, ILogger<IPService>? logger, ProxyService proxyService)
+    {
+        _context = accessor.HttpContext;
+        _logger = logger;
+        _proxyService = proxyService;
+
+        LoadIP();
+    }
+
+    private void LoadIP()
+    {
+        if (_ipLoaded) { return; }
+
+        _ipLoaded = true;
+
+        string? connectingIP = _context?.Connection.RemoteIpAddress?.ToString();
+        if (connectingIP is null) { connectingIP = ""; }
+
+        if (_proxyService.TrustedProxies.Contains(connectingIP))
+        {
+            _trustedProxy = true;
+
+            string? forwardedFor = _context?.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+            if (!string.IsNullOrEmpty(forwardedFor))
+            {
+                forwardedFor = forwardedFor.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            }
+
+            if (!string.IsNullOrEmpty(forwardedFor) &&
+                IPAddress.TryParse(forwardedFor, out _))
+            {
+                _clientIP = forwardedFor;
+            }
+        }
+
+        if (string.IsNullOrEmpty(_clientIP))
+        {
+            if (_trustedProxy)
+            {
+                LogWarning($"Trusted proxy [{connectingIP}] failed to forward client IP address.");
+            }
+
+            _clientIP = connectingIP;
+        }
+
+        if (string.IsNullOrEmpty(_clientIP))
+        {
+            LogWarning($"Unable to determine client IP address.");
+        }
+    }
+
+    private void LogWarning(string text)
+    {
+        Log(LogLevel.Warning, text);
+    }
+
+    private void LogInfo(string text)
+    {
+        Log(LogLevel.Information, text);
+    }
+
+    private void Log(LogLevel level, string text)
+    {
+        text = $"[{DateTime.Now.ToString("yyyy/MM/dd HH:mm:ss")}] {text}";
+        _logger?.Log(level, text);
+    }
+}

--- a/Services/ProxyService.cs
+++ b/Services/ProxyService.cs
@@ -1,0 +1,99 @@
+﻿
+
+using System.Net;
+
+namespace Kosync.Services;
+
+public class ProxyService
+{
+    private readonly ILogger<ProxyService>? _logger;
+
+    private bool _proxiesLoaded = false;
+
+
+    private string[] _trustedProxies = [];
+    /// <summary>
+    /// List of configured trusted proxies
+    /// </summary>
+    public string[] TrustedProxies
+    {
+        get
+        {
+            LoadProxies();
+            return _trustedProxies;
+        }
+    }
+
+
+    public ProxyService(ILogger<ProxyService> logger)
+    {
+        _logger = logger;
+    }
+
+    private void LoadProxies()
+    {
+        if (_proxiesLoaded) { return; }
+
+        _proxiesLoaded = true;
+        string? tempString;
+
+        string? proxies = Environment.GetEnvironmentVariable("TRUSTED_PROXIES");
+
+        if (string.IsNullOrEmpty(proxies))
+        {
+            LogInfo("No trusted proxies set.");
+
+            return;
+        }
+
+        string[] tempProxies = proxies.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+        for (int i = 0; i < tempProxies.Length; i++)
+        {
+            if (!IPAddress.TryParse(tempProxies[i], out _))
+            {
+                LogWarning($"Inavalid trusted proxy - {tempProxies[i]}");
+
+                tempProxies[i] = "";
+            }
+        }
+
+        _trustedProxies = tempProxies.Where(p => !string.IsNullOrEmpty(p)).ToArray();
+
+        if (_trustedProxies.Length == 0)
+        {
+            LogWarning("No valid trusted proxies set.");
+        }
+        else
+        {
+            tempString = "";
+
+            foreach (var prox in _trustedProxies)
+            {
+                if (!string.IsNullOrEmpty(tempString)) { tempString += ", "; }
+
+                tempString += prox;
+            }
+
+            tempString = "Trusted proxies: " + tempString;
+
+            LogInfo(tempString);
+        }
+    }
+
+    private void LogWarning(string text)
+    {
+        Log(LogLevel.Warning, text);
+    }
+
+    private void LogInfo(string text)
+    {
+        Log(LogLevel.Information, text);
+    }
+
+    private void Log(LogLevel level, string text)
+    {
+        text = $"[{DateTime.Now.ToString("yyyy/MM/dd HH:mm:ss")}] {text}";
+        _logger?.Log(level, text);
+    }
+}

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -2,11 +2,11 @@ namespace Kosync.Services;
 
 public class UserService
 {
+    private IHttpContextAccessor _contextAccessor;
     private KosyncDb _db;
 
-    private IHttpContextAccessor _contextAccessor;
-
     private bool userLoadAttempted = false;
+
 
     private string? _username = "";
     public string? Username
@@ -48,10 +48,11 @@ public class UserService
         }
     }
 
-    public UserService(KosyncDb db, IHttpContextAccessor contextAccessor)
+
+    public UserService(IHttpContextAccessor contextAccessor, KosyncDb db)
     {
-        _db = db;
         _contextAccessor = contextAccessor;
+        _db = db;
     }
 
     private void LoadUser()
@@ -61,6 +62,7 @@ public class UserService
         userLoadAttempted = true;
 
         string? tempUsername = _contextAccessor?.HttpContext?.Request.Headers["x-auth-user"];
+        _username = tempUsername;
 
         string? passwordHash = _contextAccessor?.HttpContext?.Request.Headers["x-auth-key"];
 
@@ -70,7 +72,6 @@ public class UserService
 
         if (user is null) { return; }
 
-        _username = tempUsername;
 
         _isAuthenticated = true;
 

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -4,11 +4,19 @@ public class UserService
 {
     private KosyncDb _db;
 
-    private IHttpContextAccessor contextAccessor;
+    private IHttpContextAccessor _contextAccessor;
 
     private bool userLoadAttempted = false;
 
-    public string? Username { get; private set; }
+    private string? _username = "";
+    public string? Username
+    {
+        get
+        {
+            LoadUser();
+            return _username;
+        }
+    }
 
     private bool _isAuthenticated = false;
     public bool IsAuthenticated
@@ -21,7 +29,6 @@ public class UserService
     }
 
     private bool _isActive = false;
-
     public bool IsActive
     {
         get
@@ -32,7 +39,6 @@ public class UserService
     }
 
     private bool _isAdmin = false;
-
     public bool IsAdmin
     {
         get
@@ -45,7 +51,7 @@ public class UserService
     public UserService(KosyncDb db, IHttpContextAccessor contextAccessor)
     {
         _db = db;
-        this.contextAccessor = contextAccessor;
+        this._contextAccessor = contextAccessor;
     }
 
     private void LoadUser()
@@ -54,12 +60,14 @@ public class UserService
 
         userLoadAttempted = true;
 
-        Username = contextAccessor?.HttpContext?.Request.Headers["x-auth-user"];
-        string? passwordHash = contextAccessor?.HttpContext?.Request.Headers["x-auth-key"];
+        _username = _contextAccessor?.HttpContext?.Request.Headers["x-auth-user"];
+        if (_username is null) { _username = ""; }
+
+        string? passwordHash = _contextAccessor?.HttpContext?.Request.Headers["x-auth-key"];
 
         var userCollection = _db.Context.GetCollection<User>("users");
 
-        var user = userCollection.FindOne(i => i.Username == Username && i.PasswordHash == passwordHash);
+        var user = userCollection.FindOne(i => i.Username == _username && i.PasswordHash == passwordHash);
 
         if (user is null) { return; }
 

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -60,16 +60,17 @@ public class UserService
 
         userLoadAttempted = true;
 
-        _username = _contextAccessor?.HttpContext?.Request.Headers["x-auth-user"];
-        if (_username is null) { _username = ""; }
+        string? tempUsername = _contextAccessor?.HttpContext?.Request.Headers["x-auth-user"];
 
         string? passwordHash = _contextAccessor?.HttpContext?.Request.Headers["x-auth-key"];
 
         var userCollection = _db.Context.GetCollection<User>("users");
 
-        var user = userCollection.FindOne(i => i.Username == _username && i.PasswordHash == passwordHash);
+        var user = userCollection.FindOne(i => i.Username == tempUsername && i.PasswordHash == passwordHash);
 
         if (user is null) { return; }
+
+        _username = tempUsername;
 
         _isAuthenticated = true;
 

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -61,14 +61,13 @@ public class UserService
 
         userLoadAttempted = true;
 
-        string? tempUsername = _contextAccessor?.HttpContext?.Request.Headers["x-auth-user"];
-        _username = tempUsername;
+        _username = _contextAccessor?.HttpContext?.Request.Headers["x-auth-user"];
 
         string? passwordHash = _contextAccessor?.HttpContext?.Request.Headers["x-auth-key"];
 
         var userCollection = _db.Context.GetCollection<User>("users");
 
-        var user = userCollection.FindOne(i => i.Username == tempUsername && i.PasswordHash == passwordHash);
+        var user = userCollection.FindOne(i => i.Username == _username && i.PasswordHash == passwordHash);
 
         if (user is null) { return; }
 

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -51,7 +51,7 @@ public class UserService
     public UserService(KosyncDb db, IHttpContextAccessor contextAccessor)
     {
         _db = db;
-        this._contextAccessor = contextAccessor;
+        _contextAccessor = contextAccessor;
     }
 
     private void LoadUser()


### PR DESCRIPTION
Added optional `TRUSTED_PROXIES` environment variable. 

`TRUSTED_PROXIES` should be a comma delineated list of IPv4 or IPv6 addresses for trusted proxies.

If a request comes in with a source IP address that is one of the trusted proxies, the X-Forwarded-For header will be checked for the client's real IP address.

If a request comes in with a source IP address that is NOT one of the trusted proxies, the source IP address will be used for logging and will be marked with an asterisk (*).

If `TRUSTED_PROXIES` is not set, the request's source IP address will be used for logging.

Log entries are now formatted as

> [yyyy-MM-dd HH:mm:ss] [1.2.3.4] log text here

Log entries for requests that come from a source that is NOT one of the trusted proxies are formatted as

> [yyyy-MM-dd HH:mm:ss] [1.2.3.4]* log text here

Added `SINGLE_LINE_LOGGING` environment variable to make log output place all data on a single line.