### PR TITLE
Force response content-type to be exactly application/json

### DIFF
--- a/Controllers/SyncController.cs
+++ b/Controllers/SyncController.cs
@@ -180,7 +180,7 @@ public class SyncController : ControllerBase
     }
 
     [HttpGet("/syncs/progress/{documentHash}")]
-    public ObjectResult GetProgress(string documentHash)
+    public IActionResult GetProgress(string documentHash)
     {
         if (!_userService.IsAuthenticated)
         {
@@ -225,14 +225,27 @@ public class SyncController : ControllerBase
         }
 
         LogInfo($"Received progress request for user [{_userService.Username}] with document hash [{documentHash}].");
-        return StatusCode(200, new
+
+        var time = new DateTimeOffset(document.Timestamp);
+
+        var result = new
         {
             device = document.Device,
             device_id = document.DeviceId,
             document = document.DocumentHash,
             percentage = document.Percentage,
-            progress = document.Progress
-        });
+            progress = document.Progress,
+            timestamp = time.ToUnixTimeSeconds()
+        };
+
+        string json = System.Text.Json.JsonSerializer.Serialize(result);
+
+        return new ContentResult()
+        {
+            Content = json,
+            ContentType = "application/json",
+            StatusCode = 200
+        };
     }
 
     private void LogInfo(string text)


### PR DESCRIPTION
As discussed in #14 and [this](https://github.com/koreader/koreader/issues/13629#issuecomment-2816647908) KOReader issue, it looks like the current problem with syncing on KOReader 2025.4 is due to how the rest client library KOReader uses reads the ```content-type``` header. 

It appears that the root cause of the problem is that Spore is looking for exactly ```application/json``` in the ``content-type``` header. When sending a response using the StatusCode method in C#, ```charset=utf-8``` is automatically appended to the ```content-type``` header. This causes Spore to mistakenly fail to recognize the response body as JSON.

By manually serializing the JSON and sending the response as a basic ContentResult we can explicitly set the ```content-type``` without C# "helping" us.
